### PR TITLE
Add SSE to event forms

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,10 +40,6 @@ export const STATIC_PATH = path.join(__dirname, '../static');
 export const BUILD_STATIC_PATH = path.join(__dirname, '../build/static');
 export const VIEWS_PATH = path.join(__dirname, '../build/views');
 
-export const READ_ALL_PROPERTIES_OP = 'readallproperties';
-export const SUBSCRIBE_ALL_EVENTS_OP = 'subscribeallevents';
-export const UNSUBSCRIBE_ALL_EVENTS_OP = 'unsubscribeallevents';
-
 // Plugin and REST/websocket API things
 export const ACTION_STATUS = 'actionStatus';
 export const ADAPTER_ADDED = 'adapterAdded';
@@ -86,6 +82,11 @@ export enum LogSeverity {
   PROMPT = 4,
 }
 
+export enum WoTOperation {
+  READ_ALL_PROPERTIES_OP = 'readallproperties',
+  SUBSCRIBE_ALL_EVENTS_OP = 'subscribeallevents',
+  UNSUBSCRIBE_ALL_EVENTS_OP = 'unsubscribeallevents',
+}
 export interface LogMessage {
   severity: LogSeverity;
   message: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,10 @@ export const STATIC_PATH = path.join(__dirname, '../static');
 export const BUILD_STATIC_PATH = path.join(__dirname, '../build/static');
 export const VIEWS_PATH = path.join(__dirname, '../build/views');
 
+export const READ_ALL_PROPERTIES_OP = 'readallproperties';
+export const SUBSCRIBE_ALL_EVENTS_OP = 'subscribeallevents';
+export const UNSUBSCRIBE_ALL_EVENTS_OP = 'unsubscribeallevents';
+
 // Plugin and REST/websocket API things
 export const ACTION_STATUS = 'actionStatus';
 export const ADAPTER_ADDED = 'adapterAdded';

--- a/src/models/thing.ts
+++ b/src/models/thing.ts
@@ -141,6 +141,7 @@ export default class Thing extends EventEmitter {
     this.events = description.events || {};
     this.connected = false;
     this.eventsDispatched = [];
+    this.forms = [];
 
     if (description.properties) {
       for (const propertyName in description.properties) {
@@ -172,23 +173,24 @@ export default class Thing extends EventEmitter {
 
         this.properties[propertyName] = property;
       }
-    }
 
-    this.forms = [];
-
-    // If there are properties, add a top level form for them
-    if (Object.keys(description.properties).length > 0) {
-      this.forms.push({
-        href: `${this.href}/properties`,
-        op: Constants.READ_ALL_PROPERTIES_OP,
-      });
+      // If there are properties, add a top level form for them
+      if (Object.keys(description.properties).length > 0) {
+        this.forms.push({
+          href: `${this.href}/properties`,
+          op: Constants.WoTOperation.READ_ALL_PROPERTIES_OP,
+        });
+      }
     }
 
     // If there are events, add a top level form for them
-    if (Object.keys(description.events).length > 0) {
+    if (Object.keys(description.events ?? {}).length > 0) {
       this.forms.push({
         href: `${this.href}/events`,
-        op: [Constants.SUBSCRIBE_ALL_EVENTS_OP, Constants.UNSUBSCRIBE_ALL_EVENTS_OP],
+        op: [
+          Constants.WoTOperation.SUBSCRIBE_ALL_EVENTS_OP,
+          Constants.WoTOperation.UNSUBSCRIBE_ALL_EVENTS_OP,
+        ],
         subprotocol: 'sse',
       });
     }
@@ -678,7 +680,7 @@ export default class Thing extends EventEmitter {
 
     // Update description
     this.description = description.description || '';
-
+    this.forms = [];
     // Update properties
     this.properties = {};
     if (description.properties) {
@@ -709,6 +711,14 @@ export default class Thing extends EventEmitter {
           href: `${this.href}${Constants.PROPERTIES_PATH}/${encodeURIComponent(propertyName)}`,
         });
         this.properties[propertyName] = property;
+      }
+
+      // If there are properties, add a top level form for them
+      if (Object.keys(description.properties).length > 0) {
+        this.forms.push({
+          href: `${this.href}/properties`,
+          op: Constants.WoTOperation.READ_ALL_PROPERTIES_OP,
+        });
       }
     }
 
@@ -770,21 +780,14 @@ export default class Thing extends EventEmitter {
       });
     }
 
-    this.forms = [];
-
-    // If there are properties, add a top level form for them
-    if (Object.keys(description.properties).length > 0) {
-      this.forms.push({
-        href: `${this.href}/properties`,
-        op: Constants.READ_ALL_PROPERTIES_OP,
-      });
-    }
-
     // If there are events, add a top level form for them
-    if (Object.keys(description.events).length > 0) {
+    if (Object.keys(description.events ?? {}).length > 0) {
       this.forms.push({
         href: `${this.href}/events`,
-        op: [Constants.SUBSCRIBE_ALL_EVENTS_OP, Constants.UNSUBSCRIBE_ALL_EVENTS_OP],
+        op: [
+          Constants.WoTOperation.SUBSCRIBE_ALL_EVENTS_OP,
+          Constants.WoTOperation.UNSUBSCRIBE_ALL_EVENTS_OP,
+        ],
         subprotocol: 'sse',
       });
     }

--- a/src/models/thing.ts
+++ b/src/models/thing.ts
@@ -174,12 +174,25 @@ export default class Thing extends EventEmitter {
       }
     }
 
-    this.forms = [
-      {
+    this.forms = [];
+
+    // If there are properties, add a top level form for them
+    if (Object.keys(description.properties).length > 0) {
+      this.forms.push({
         href: `${this.href}/properties`,
-        op: ['readallproperties', 'writeallproperties'],
-      },
-    ];
+        op: Constants.READ_ALL_PROPERTIES_OP,
+      });
+    }
+
+    // If there are events, add a top level form for them
+    if (Object.keys(description.events).length > 0) {
+      this.forms.push({
+        href: `${this.href}/events`,
+        op: [Constants.SUBSCRIBE_ALL_EVENTS_OP, Constants.UNSUBSCRIBE_ALL_EVENTS_OP],
+        subprotocol: 'sse',
+      });
+    }
+
     this.floorplanVisibility = description.floorplanVisibility;
     this.floorplanX = description.floorplanX;
     this.floorplanY = description.floorplanY;
@@ -189,10 +202,6 @@ export default class Thing extends EventEmitter {
       {
         rel: 'actions',
         href: `${this.href}/actions`,
-      },
-      {
-        rel: 'events',
-        href: `${this.href}/events`,
       },
     ];
 
@@ -281,6 +290,7 @@ export default class Thing extends EventEmitter {
       // Give the event a URL
       event.forms.push({
         href: `${this.href}${Constants.EVENTS_PATH}/${encodeURIComponent(eventName)}`,
+        subprotocol: 'sse',
       });
     }
 
@@ -756,6 +766,26 @@ export default class Thing extends EventEmitter {
       // Give the event a URL
       event.forms.push({
         href: `${this.href}${Constants.EVENTS_PATH}/${encodeURIComponent(eventName)}`,
+        subprotocol: 'sse',
+      });
+    }
+
+    this.forms = [];
+
+    // If there are properties, add a top level form for them
+    if (Object.keys(description.properties).length > 0) {
+      this.forms.push({
+        href: `${this.href}/properties`,
+        op: Constants.READ_ALL_PROPERTIES_OP,
+      });
+    }
+
+    // If there are events, add a top level form for them
+    if (Object.keys(description.events).length > 0) {
+      this.forms.push({
+        href: `${this.href}/events`,
+        op: [Constants.SUBSCRIBE_ALL_EVENTS_OP, Constants.UNSUBSCRIBE_ALL_EVENTS_OP],
+        subprotocol: 'sse',
       });
     }
 


### PR DESCRIPTION
This is an update to the forms of Thing Descriptions to reflect the Server-Sent Events implementation in https://github.com/WebThingsIO/gateway/pull/2863

Notes:
1. This adds a subprotocol member to event forms with a value of 'sse'
2. A top level form for properties or events is only added if the thing has properties or events respectively
3. I've removed the writeallproperties op from properties at the same time since I don't think it's actually supported in the API
4. I don't add a subprotocol member to proxied forms, I'm not sure whether or not this is the best thing to do